### PR TITLE
Revert "auto exclude test renaissance-db-shootout_0 vendor=abc plat=^((?!(x86-64_linux|x86-64_mac|x86-64_windows)).)*$"

### DIFF
--- a/perf/renaissance/playlist.xml
+++ b/perf/renaissance/playlist.xml
@@ -51,12 +51,6 @@
 	</test>
 	<test>
 		<testCaseName>renaissance-db-shootout</testCaseName>
-		<disabled>
-			<comment>https://github.com/renfeiw/repo1/issues/60#issuecomment-770146469</comment>
-			<variation>NoOptions</variation>
-			<vendor>abc</vendor>
-			<plat>^((?!(x86-64_linux|x86-64_mac|x86-64_windows)).)*$</plat>
-		</disabled>
 		<command>$(JAVA_COMMAND) -jar $(Q)$(TEST_RESROOT)$(D)renaissance-mit.jar$(Q) --json $(Q)$(REPORTDIR)$(D)db-shootout.json$(Q) db-shootout; \
 		$(TEST_STATUS)</command>
 		<!-- Issue https://github.com/renaissance-benchmarks/renaissance/issues/210 -->


### PR DESCRIPTION
Reverts renfeiw/repo1#66